### PR TITLE
Change `AliasesService` to use manual YAML parsing instead of `YamlDotNet`

### DIFF
--- a/Flow.Launcher.Plugin.Obsidian/Flow.Launcher.Plugin.Obsidian.csproj
+++ b/Flow.Launcher.Plugin.Obsidian/Flow.Launcher.Plugin.Obsidian.csproj
@@ -23,7 +23,6 @@
 
   <ItemGroup>
     <PackageReference Include="Flow.Launcher.Plugin" Version="4.4.0"/>
-    <PackageReference Include="YamlDotNet" Version="16.2.0"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/Flow.Launcher.Plugin.Obsidian/Models/Vault.cs
+++ b/Flow.Launcher.Plugin.Obsidian/Models/Vault.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Flow.Launcher.Plugin.Obsidian.Services;
-using YamlDotNet.Serialization;
 
 namespace Flow.Launcher.Plugin.Obsidian.Models;
 
@@ -28,6 +27,12 @@ public class Vault
         if (!HasAdvancedUri) VaultSetting.OpenInNewTabByDefault = false;
     }
 
+    public bool OpenNoteInNewTabByDefault(GlobalVaultSetting globalSetting)
+    {
+        if (!HasAdvancedUri) return false;
+        return VaultSetting.UseGlobalSetting ? globalSetting.OpenInNewTabByDefault : VaultSetting.OpenInNewTabByDefault;
+    }
+
     private List<File> GetFiles(Settings settings)
     {
         bool useAliases = settings.UseAliases;
@@ -46,18 +51,11 @@ public class Vault
             {
                 string[]? aliases = null;
                 if (!useAliases) return new File(this, filePath, aliases);
-                Deserializer deserializer = new();
-                aliases = AliasesService.GetAliases(filePath, deserializer);
+                aliases = AliasesService.GetAliases(filePath);
                 return new File(this, filePath, aliases);
             })
             .ToList();
 
         return files;
-    }
-
-    public bool OpenNoteInNewTabByDefault(GlobalVaultSetting globalSetting)
-    {
-        if (!HasAdvancedUri) return false;
-        return VaultSetting.UseGlobalSetting ? globalSetting.OpenInNewTabByDefault : VaultSetting.OpenInNewTabByDefault;
     }
 }


### PR DESCRIPTION
Implement manual YAML parsing.
Remove not used anymore `YamlDotNet` dependency.

Should fix Invalid YAML crash #5.