### PR TITLE
Change content search separator

### DIFF
--- a/Flow.Launcher.Plugin.Obsidian/Utilities/ContentSearch.cs
+++ b/Flow.Launcher.Plugin.Obsidian/Utilities/ContentSearch.cs
@@ -10,6 +10,8 @@ namespace Flow.Launcher.Plugin.Obsidian.Utilities;
 
 public static class ContentSearch
 {
+    public const char Separator = '|';
+
     private const int TitleBaseScore = 10;
     private const int EndOfLineScore = 3;
     private const int StartOfLineScore = 3;

--- a/Flow.Launcher.Plugin.Obsidian/Utilities/SearchUtility.cs
+++ b/Flow.Launcher.Plugin.Obsidian/Utilities/SearchUtility.cs
@@ -95,7 +95,7 @@ public static class SearchUtility
         }
 
         string matchedWord = bestMatch.ExtractMatchedWord();
-        file.Title = $"{file.Name} - {matchedWord}";
+        file.Title = $"{file.Name} {ContentSearch.Separator} {matchedWord}";
         file.Score = bestMatch.Score;
         return file;
     }


### PR DESCRIPTION
Use `|` to split note tile from content search result insted of `-` since the `-` can be in file name and could cause confusion for the users that use them.

The new char what added as const inside ContentSearch